### PR TITLE
RM7316: Added autoload of the  imx_rpmsg_tty module

### DIFF
--- a/recipes-kernel/linux/linux-imx_%.bbappend
+++ b/recipes-kernel/linux/linux-imx_%.bbappend
@@ -4,4 +4,4 @@ SRC_URI += "file://0001-RM7276-Port-NAVQ-board-support-to-NXP-BSP-6.6.52_2.2.pat
             file://devtool-fragment.cfg \
             file://0002-RM-7316-Add-M4-support-for-NAVQ-board-in-the-NXP-BSP.patch \
             "
-
+KERNEL_MODULE_AUTOLOAD += "imx_rpmsg_tty"


### PR DESCRIPTION
Build imx-image-full and install the image on the target
Check that the imx_rpmsg_tty module has been loaded
root@imx8mm-som-gp:~# lsmod
Module                  Size  Used by
caam                   24576  0
secvio                 16384  0
error                  20480  2 secvio,caam
overlay               135168  0
crct10dif_ce           12288  1
polyval_ce             12288  0
polyval_generic        12288  1 polyval_ce
imx_rpmsg_tty          12288  0
fuse                  131072  1