### PR TITLE
RM-7315: Added auto running of the Qt example

### DIFF
--- a/recipes-core/images/emcraft-rootfs.bb
+++ b/recipes-core/images/emcraft-rootfs.bb
@@ -1,0 +1,8 @@
+# Copyrigh (C) 2025 Emcraft Systems
+# IMX8MMINI-SOM root filesystem image
+
+require dynamic-layers/qt6-layer/recipes-fsl/images/imx-image-full.bb
+
+IMAGE_INSTALL += " \
+    qt-demo \
+"

--- a/recipes-core/qt-demo/files/run-qtdemo.service
+++ b/recipes-core/qt-demo/files/run-qtdemo.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Run Qt example
+
+After=graphical.target
+
+[Service]
+Type=oneshot
+Environment="QT_QPA_PLATFORM=wayland-egl"
+Environment="WAYLAND_DISPLAY=/run/wayland-0"
+ExecStart=/usr/sbin/run-qtdemo.sh
+RemainAfterExit=true
+StandardOutput=journal
+
+[Install]
+WantedBy=graphical.target

--- a/recipes-core/qt-demo/files/run-qtdemo.sh
+++ b/recipes-core/qt-demo/files/run-qtdemo.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if test -z $XDG_RUNTIME_DIR; then
+        export XDG_RUNTIME_DIR=/run/user/$(id -u)
+        if [ ! -d $XDG_RUNTIME_DIR ]; then
+                mkdir -m 700 -p $XDG_RUNTIME_DIR
+        fi
+fi
+
+/usr/share/examples/quick3d/hellocube/bin/hellocube &

--- a/recipes-core/qt-demo/qt-demo.bb
+++ b/recipes-core/qt-demo/qt-demo.bb
@@ -1,0 +1,26 @@
+SUMMARY = "Qt example which run after system booting"
+
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-or-later;md5=fed54355545ffd980b814dab4a3b312c"
+#FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+inherit systemd
+SYSTEMD_AUTO_ENABLE = "enable"
+SYSTEMD_SERVICE:${PN} = "run-qtdemo.service"
+
+SRC_URI = "file://run-qtdemo.service \
+           file://run-qtdemo.sh \
+	   "
+SYSTEMD_SERVICE:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'run-qtdemo.service', '', d)}"
+S = "${WORKDIR}"
+
+IMXSOC = "IMX8MM"
+
+do_install:append() {
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then    
+	install -d ${D}${sbindir}
+	install -m 0755 ${S}/run-qtdemo.sh ${D}${sbindir}/run-qtdemo.sh
+
+	install -d ${D}${systemd_unitdir}/system
+	install -m 0644 ${S}/run-qtdemo.service ${D}${systemd_unitdir}/system
+    fi
+}


### PR DESCRIPTION
1. Build the image by the bitbake emcraft-rootfs command
2. Install the resultant image to the target board
3. Boot the system to shell
4. Check the Qt example is running
`root@imx8mm-som-gp:~# ps -x | grep hello
    694 ?        Sl     0:05 /usr/share/examples/quick3d/hellocube/bin/hellocube
    739 ttymxc1  S+     0:00 grep hello
`