### PR TITLE
RM7482: Enabled internal pullups on UART2 console pins.

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx/0001-RM7482-Enabled-pullups-on-UART2-console-pins.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/0001-RM7482-Enabled-pullups-on-UART2-console-pins.patch
@@ -1,0 +1,22 @@
+From 957f9149ed66d5acd8086e295fbe7f9a1d8365fe Mon Sep 17 00:00:00 2001
+From: Sergei Poselenov <sposelenov@emcraft.com>
+Date: Wed, 22 Oct 2025 14:23:46 +0000
+Subject: [PATCH] RM7482: Enabled pullups on UART2 console pins.
+
+---
+ board/freescale/imx8mm_navq/imx8mm_navq.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/board/freescale/imx8mm_navq/imx8mm_navq.c b/board/freescale/imx8mm_navq/imx8mm_navq.c
+index c7bd9fba2cd..eaddae8f568 100644
+--- a/board/freescale/imx8mm_navq/imx8mm_navq.c
++++ b/board/freescale/imx8mm_navq/imx8mm_navq.c
+@@ -23,7 +23,7 @@
+ 
+ DECLARE_GLOBAL_DATA_PTR;
+ 
+-#define UART_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_FSEL1)
++#define UART_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_FSEL1 | PAD_CTL_PUE | PAD_CTL_PE)
+ #define WDOG_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_ODE | PAD_CTL_PUE | PAD_CTL_PE)
+ 
+ static iomux_v3_cfg_t const uart_pads[] = {

--- a/recipes-bsp/u-boot/u-boot-imx_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-imx_%.bbappend
@@ -1,4 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-SRC_URI += "file://0001-Initial-port-of-i.MX8MM-NAVQ-board-support.patch"
+SRC_URI += "file://0001-Initial-port-of-i.MX8MM-NAVQ-board-support.patch \
+            file://0001-RM7482-Enabled-pullups-on-UART2-console-pins.patch \
+            "
 


### PR DESCRIPTION
Enabled internal pullups on the U-Boot console pins, to avoid floating Rx stopping auto-boot.

Tested by the clean build.